### PR TITLE
fix: Throttle visits counter dynamically on IP

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
     "Coolmath",
     "Grebel",
     "haha",
+    "ipaddr",
     "lichess",
     "Monkeytype",
     "shadcn",

--- a/actions/middleware/views.ts
+++ b/actions/middleware/views.ts
@@ -15,6 +15,10 @@ export async function incrViews(ip: string, categories: string[]) {
     return false;
   }
 
+  console.log("Attempting to get total global views...");
+  const totalVisits = await redis.get("global_views");
+  console.log(`Total global views: ${totalVisits}`);
+
   const visits = await redis.incr(ip);
 
   console.log(`Total visits from IP "${ip}": ${visits}`);
@@ -36,8 +40,7 @@ export async function incrViews(ip: string, categories: string[]) {
     }
   } catch (error) {
     console.error("Failed to update global page views:", error);
-    // return NextResponse.json({ error: "Failed to update data", status: 500 });
-    return NextResponse.error();
+    return NextResponse.json({ error: "Failed to update data", status: 500 });
   }
 
   return updated;

--- a/actions/middleware/views.ts
+++ b/actions/middleware/views.ts
@@ -2,61 +2,47 @@
 
 import redis from "@/lib/redis";
 import { isProd } from "@/lib/utils";
-import { NextResponse } from "next/server";
+import { NextFetchEvent } from "next/server";
 
 /**
  * Middleware to increment the views from a given IP address.
  *
  * @returns {boolean} Whether the views were incremented.
  */
-export async function incrViews(ip: string, categories: string[]) {
+export async function incrViews(
+  ip: string,
+  context: NextFetchEvent,
+  categories: string[]
+) {
   if (!isProd()) {
-    console.log("Skipping view increment in development mode.");
     return false;
   }
-
-  console.log("Attempting to get total global views...");
-  const totalVisits = await redis.get("global_views");
-  console.log(`Total global views: ${totalVisits}`);
 
   const visits = await redis.incr(ip);
 
   console.log(`Total visits from IP "${ip}": ${visits}`);
 
   if (visits > 1) {
-    console.log(`Skipping view increment for IP "${ip}" (already visited).`);
     return false;
   }
 
-  await redis.expire(ip, 60);
+  await redis.expire(ip, 60 * 60 * 24);
 
   let updated = false;
 
-  try {
-    for (const category of categories) {
-      await redis.incr(category);
-      console.log(`Successfully incremented "${category}" by 1.`);
-      updated = true;
-    }
-  } catch (error) {
-    console.error("Failed to update global page views:", error);
-    return NextResponse.json({ error: "Failed to update data", status: 500 });
-  }
-
-  /*
   context.waitUntil(
     (async () => {
       try {
         for (const category of categories) {
           await redis.incr(category);
+          console.log(`Successfully incremented "${category}" from IP ${ip}.`);
           updated = true;
         }
       } catch (error) {
-        console.error("Failed to update global page views:", error);
+        console.error("Failed to increment categories:", error);
       }
     })()
   );
-  */
 
   return updated;
 }

--- a/actions/middleware/views.ts
+++ b/actions/middleware/views.ts
@@ -43,5 +43,20 @@ export async function incrViews(ip: string, categories: string[]) {
     return NextResponse.json({ error: "Failed to update data", status: 500 });
   }
 
+  /*
+  context.waitUntil(
+    (async () => {
+      try {
+        for (const category of categories) {
+          await redis.incr(category);
+          updated = true;
+        }
+      } catch (error) {
+        console.error("Failed to update global page views:", error);
+      }
+    })()
+  );
+  */
+
   return updated;
 }

--- a/actions/middleware/views.ts
+++ b/actions/middleware/views.ts
@@ -16,6 +16,8 @@ export async function incrViews(ip: string, categories: string[]) {
 
   const visits = await redis.incr(ip);
 
+  console.log(`Total visits from IP "${ip}": ${visits}`);
+
   if (visits > 1) {
     console.log(`Skipping view increment for IP "${ip}" (already visited).`);
     return false;

--- a/actions/middleware/views.ts
+++ b/actions/middleware/views.ts
@@ -7,20 +7,18 @@ import { NextFetchEvent } from "next/server";
 /**
  * Middleware to increment the views from a given IP address.
  *
- * @returns {boolean} Whether the views were incremented.
+ * @returns {Promise<boolean>} Whether the views were incremented.
  */
 export async function incrViews(
   ip: string,
   context: NextFetchEvent,
   categories: string[]
-) {
+): Promise<boolean> {
   if (!isProd()) {
     return false;
   }
 
   const visits = await redis.incr(ip);
-
-  console.log(`Total visits from IP "${ip}": ${visits}`);
 
   if (visits > 1) {
     return false;
@@ -39,7 +37,7 @@ export async function incrViews(
           updated = true;
         }
       } catch (error) {
-        console.error("Failed to increment categories:", error);
+        console.error("Failed to increment:", error);
       }
     })()
   );

--- a/actions/middleware/views.ts
+++ b/actions/middleware/views.ts
@@ -1,26 +1,23 @@
 "use server";
 
 import redis from "@/lib/redis";
-import { inProd } from "@/lib/utils";
-import { NextFetchEvent } from "next/server";
+import { isProd } from "@/lib/utils";
 
 /**
  * Middleware to increment the views from a given IP address.
  *
  * @returns {boolean} Whether the views were incremented.
  */
-export async function incrViews(
-  ip: string,
-  context: NextFetchEvent,
-  categories: string[]
-) {
-  if (!inProd()) {
+export async function incrViews(ip: string, categories: string[]) {
+  if (!isProd()) {
+    console.log("Skipping view increment in development mode.");
     return false;
   }
 
   const visits = await redis.incr(ip);
 
   if (visits > 1) {
+    console.log(`Skipping view increment for IP "${ip}" (already visited).`);
     return false;
   }
 
@@ -28,18 +25,15 @@ export async function incrViews(
 
   let updated = false;
 
-  context.waitUntil(
-    (async () => {
-      try {
-        for (const category of categories) {
-          await redis.incr(category);
-          updated = true;
-        }
-      } catch (error) {
-        console.error("Failed to update global page views:", error);
-      }
-    })()
-  );
+  try {
+    for (const category of categories) {
+      await redis.incr(category);
+      console.log(`Successfully incremented "${category}" by 1.`);
+      updated = true;
+    }
+  } catch (error) {
+    console.error("Failed to update global page views:", error);
+  }
 
   return updated;
 }

--- a/actions/middleware/views.ts
+++ b/actions/middleware/views.ts
@@ -2,6 +2,7 @@
 
 import redis from "@/lib/redis";
 import { isProd } from "@/lib/utils";
+import { NextResponse } from "next/server";
 
 /**
  * Middleware to increment the views from a given IP address.
@@ -35,6 +36,8 @@ export async function incrViews(ip: string, categories: string[]) {
     }
   } catch (error) {
     console.error("Failed to update global page views:", error);
+    // return NextResponse.json({ error: "Failed to update data", status: 500 });
+    return NextResponse.error();
   }
 
   return updated;

--- a/app/api/views/route.ts
+++ b/app/api/views/route.ts
@@ -1,10 +1,11 @@
 import { NextResponse } from "next/server";
 import redis from "@/lib/redis";
 import { FALLBACK_TOTAL_VISITORS } from "@/lib/constants";
-import { inProd } from "@/lib/utils";
+import { isProd } from "@/lib/utils";
 
 export async function GET() {
-  if (!inProd()) {
+  if (!isProd()) {
+    console.log("Skipping view increment in development mode.");
     return NextResponse.json({ globalViews: FALLBACK_TOTAL_VISITORS });
   }
 

--- a/app/api/views/route.ts
+++ b/app/api/views/route.ts
@@ -5,7 +5,6 @@ import { isProd } from "@/lib/utils";
 
 export async function GET() {
   if (!isProd()) {
-    console.log("Skipping view increment in development mode.");
     return NextResponse.json({ globalViews: FALLBACK_TOTAL_VISITORS });
   }
 

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -32,7 +32,7 @@ export default function manifest(): MetadataRoute.Manifest {
         type: "image/png",
       },
       {
-        src: "/images/favicon256.png",
+        src: "/icons/favicon256.png",
         sizes: "256x256",
         type: "image/png",
       },

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,6 +1,6 @@
-import { inProd } from "./utils";
+import { isProd } from "./utils";
 
-export const BASE_URL = inProd()
+export const BASE_URL = isProd()
   ? "https://plett.dev"
   : "http://localhost:3000";
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -14,4 +14,4 @@ export const URL_OLD_SITE = "https://old.plett.dev";
 export const COPYRIGHT_STRING = `Copyright ${new Date().getFullYear()} © Josiah Plett`;
 
 export const VISITOR_EXPIRATION = 60 * 60 * 24;
-export const FALLBACK_TOTAL_VISITORS = 63; // NOTE: Old website had 1080 views as of 2024-10-28.
+export const FALLBACK_TOTAL_VISITORS = 79; // NOTE: Old website had 1080 views as of 2024-10-28.

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -13,4 +13,5 @@ export const URL_OLD_SITE = "https://old.plett.dev";
 
 export const COPYRIGHT_STRING = `Copyright ${new Date().getFullYear()} © Josiah Plett`;
 
-export const FALLBACK_TOTAL_VISITORS = 47; // NOTE: Old website had 1080 views as of 2024-10-28.
+export const VISITOR_EXPIRATION = 60 * 60 * 24;
+export const FALLBACK_TOTAL_VISITORS = 63; // NOTE: Old website had 1080 views as of 2024-10-28.

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -13,4 +13,4 @@ export const URL_OLD_SITE = "https://old.plett.dev";
 
 export const COPYRIGHT_STRING = `Copyright ${new Date().getFullYear()} © Josiah Plett`;
 
-export const FALLBACK_TOTAL_VISITORS = 37; // NOTE: Old website had 1080 views as of 2024-10-28.
+export const FALLBACK_TOTAL_VISITORS = 47; // NOTE: Old website had 1080 views as of 2024-10-28.

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -1,6 +1,7 @@
 import { Redis } from "@upstash/redis";
 import { isProd } from "./utils";
 
+// NOTE: This singleton is not necessary, but it's good practice.
 const redisSingleton = () => {
   return new Redis({
     url: process.env.UPSTASH_REDIS_REST_URL!,

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -1,8 +1,19 @@
 import { Redis } from "@upstash/redis";
+import { isProd } from "./utils";
 
-const redis = new Redis({
-  url: process.env.UPSTASH_REDIS_REST_URL!,
-  token: process.env.UPSTASH_REDIS_REST_TOKEN!,
-});
+const redisSingleton = () => {
+  return new Redis({
+    url: process.env.UPSTASH_REDIS_REST_URL!,
+    token: process.env.UPSTASH_REDIS_REST_TOKEN!,
+  });
+};
+
+declare const globalThis: {
+  redisGlobal: ReturnType<typeof redisSingleton>;
+} & typeof global;
+
+const redis = globalThis.redisGlobal ?? redisSingleton();
+
+if (!isProd()) globalThis.redisGlobal = redis;
 
 export default redis;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -43,6 +43,7 @@ export function addOrdinalSuffix(i: number): string {
   return i + "th";
 }
 
-export function inProd() {
-  return process.env.NODE_ENV === "production";
+export function isProd() {
+  // return process.env.NODE_ENV === "production";
+  return true;
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,5 +1,6 @@
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
+import ipaddr from "ipaddr.js";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -43,7 +44,24 @@ export function addOrdinalSuffix(i: number): string {
   return i + "th";
 }
 
-export function isProd() {
+/**
+ * Helper function for grouping public IP addresses.
+ */
+export function processIp(ip: string): string {
+  const parsedIp = ipaddr.parse(ip);
+
+  if (parsedIp.range() !== "private") {
+    const [a, b] =
+      parsedIp.kind() === "ipv4"
+        ? (parsedIp as ipaddr.IPv4).octets
+        : (parsedIp as ipaddr.IPv6).parts;
+    ip = `${a}.${b}`;
+  }
+
+  return ip;
+}
+
+export function isProd(): boolean {
   // return process.env.NODE_ENV === "production";
   return true;
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -12,8 +12,8 @@ export default async function middleware(
 ) {
   const response = NextResponse.next();
 
-  // const ip = request.headers.get("x-forwarded-for") || request.ip || "unknown";
-  const ip = request.ip ?? "unknown";
+  const forwarded = request.headers.get("x-forwarded-for");
+  const ip = forwarded ? forwarded.split(/, /)[0] : request.ip ?? "unknown";
 
   await incrViews(ip, context, ["global_views"]);
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -13,7 +13,7 @@ export default async function middleware(request: NextRequest) {
 
   console.log("Middleware running on IP: ", ip);
 
-  incrViews(ip, ["global_views"]);
+  await incrViews(ip, ["global_views"]);
 
   return response;
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -12,7 +12,8 @@ export default async function middleware(
 ) {
   const response = NextResponse.next();
 
-  const ip = request.headers.get("x-forwarded-for") || request.ip || "unknown";
+  // const ip = request.headers.get("x-forwarded-for") || request.ip || "unknown";
+  const ip = request.ip ?? "unknown";
 
   await incrViews(ip, context, ["global_views"]);
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -3,29 +3,14 @@ import { incrViews } from "./actions/middleware/views";
 
 // TODO: Improve my matcher.
 
-export const config = {
-  matcher: [
-    /*
-     * Match all request paths except for the ones starting with:
-     * - api (API routes)
-     * - _next/static (static files)
-     * - _next/image (image optimization files)
-     * - favicon.png (favicon file)
-     */
-    {
-      source: "/((?!api|_next/static|_next/image|favicon.png).*)",
-      missing: [
-        { type: "header", key: "next-router-prefetch" },
-        { type: "header", key: "purpose", value: "prefetch" },
-      ],
-    },
-  ],
-};
-
 export default async function middleware(request: NextRequest) {
   const response = NextResponse.next();
 
-  incrViews(request.ip ?? "unknown", ["global_views"]);
+  const ip = request.headers.get("x-forwarded-for") || request.ip || "unknown";
+
+  console.log("Middleware running on IP: ", ip);
+
+  incrViews(ip, ["global_views"]);
 
   return response;
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,9 +2,8 @@ import { NextFetchEvent, NextRequest, NextResponse } from "next/server";
 import { incrViews } from "./actions/middleware/views";
 import { processIp } from "./lib/utils";
 
-// TODO: Improve my matcher.
 export const config = {
-  matcher: ["/about/:path*", "/posts/:path*"],
+  matcher: ["/", "/about", "/posts/:path*"],
 };
 
 export default async function middleware(

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,6 @@
 import { NextFetchEvent, NextRequest, NextResponse } from "next/server";
 import { incrViews } from "./actions/middleware/views";
+import ipaddr from "ipaddr.js";
 
 // TODO: Improve my matcher.
 export const config = {
@@ -14,6 +15,11 @@ export default async function middleware(
 
   const forwarded = request.headers.get("x-forwarded-for");
   const ip = forwarded ? forwarded.split(/, /)[0] : request.ip ?? "unknown";
+
+  // Ensure public IP addresses are not counted.
+  if (ipaddr.parse("192.168.5.1").range() !== "private") {
+    return response;
+  }
 
   await incrViews(ip, context, ["global_views"]);
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,6 @@
 import { NextFetchEvent, NextRequest, NextResponse } from "next/server";
 import { incrViews } from "./actions/middleware/views";
-import ipaddr from "ipaddr.js";
+import { processIp } from "./lib/utils";
 
 // TODO: Improve my matcher.
 export const config = {
@@ -13,13 +13,11 @@ export default async function middleware(
 ) {
   const response = NextResponse.next();
 
-  const forwarded = request.headers.get("x-forwarded-for");
-  const ip = forwarded ? forwarded.split(/, /)[0] : request.ip ?? "unknown";
-
-  // Ensure public IP addresses are not counted.
-  if (ipaddr.parse("192.168.5.1").range() !== "private") {
-    return response;
-  }
+  const forwardedIp = request.headers.get("x-forwarded-for");
+  const rawIp = forwardedIp
+    ? forwardedIp.split(/, /)[0]
+    : request.ip ?? "unknown";
+  const ip = processIp(rawIp);
 
   await incrViews(ip, context, ["global_views"]);
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,49 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import redis from "@/lib/redis";
-import { isProd } from "@/lib/utils";
-
-// import { incrViews } from "./actions/middleware/views";
-
-/**
- * Middleware to increment the views from a given IP address.
- *
- * @returns {boolean} Whether the views were incremented.
- */
-export async function incrViews(ip: string, categories: string[]) {
-  console.log("Attempting to increment views from IP: ", ip);
-
-  if (!isProd()) {
-    console.log("Skipping view increment in development mode.");
-    return false;
-  }
-
-  const visits = await redis.incr(ip);
-
-  console.log(`Total visits from IP "${ip}": ${visits}`);
-
-  if (visits > 1) {
-    console.log(`Skipping view increment for IP "${ip}" (already visited).`);
-    return false;
-  }
-
-  await redis.expire(ip, 60);
-
-  let updated = false;
-
-  try {
-    for (const category of categories) {
-      await redis.incr(category);
-      console.log(`Successfully incremented "${category}" by 1.`);
-      updated = true;
-    }
-  } catch (error) {
-    console.error("Failed to update global page views:", error);
-    // return NextResponse.json({ error: "Failed to update data", status: 500 });
-    return NextResponse.error();
-  }
-
-  return updated;
-}
+import { incrViews } from "./actions/middleware/views";
 
 // TODO: Improve my matcher.
 export const config = {

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,4 +1,4 @@
-import { NextFetchEvent, NextRequest, NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { incrViews } from "./actions/middleware/views";
 
 // TODO: Improve my matcher.
@@ -22,13 +22,12 @@ export const config = {
   ],
 };
 
-export default async function middleware(
-  request: NextRequest,
-  context: NextFetchEvent
-) {
+export default async function middleware(request: NextRequest) {
   const response = NextResponse.next();
 
-  incrViews(request.ip ?? "unknown", context, ["global_views"]);
+  console.log(request.body, request.ip);
+
+  incrViews(request.ip ?? "unknown", ["global_views"]);
 
   return response;
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,7 +1,54 @@
 import { NextRequest, NextResponse } from "next/server";
-import { incrViews } from "./actions/middleware/views";
+import redis from "@/lib/redis";
+import { isProd } from "@/lib/utils";
+
+// import { incrViews } from "./actions/middleware/views";
+
+/**
+ * Middleware to increment the views from a given IP address.
+ *
+ * @returns {boolean} Whether the views were incremented.
+ */
+export async function incrViews(ip: string, categories: string[]) {
+  console.log("Attempting to increment views from IP: ", ip);
+
+  if (!isProd()) {
+    console.log("Skipping view increment in development mode.");
+    return false;
+  }
+
+  const visits = await redis.incr(ip);
+
+  console.log(`Total visits from IP "${ip}": ${visits}`);
+
+  if (visits > 1) {
+    console.log(`Skipping view increment for IP "${ip}" (already visited).`);
+    return false;
+  }
+
+  await redis.expire(ip, 60);
+
+  let updated = false;
+
+  try {
+    for (const category of categories) {
+      await redis.incr(category);
+      console.log(`Successfully incremented "${category}" by 1.`);
+      updated = true;
+    }
+  } catch (error) {
+    console.error("Failed to update global page views:", error);
+    // return NextResponse.json({ error: "Failed to update data", status: 500 });
+    return NextResponse.error();
+  }
+
+  return updated;
+}
 
 // TODO: Improve my matcher.
+export const config = {
+  matcher: ["/about/:path*", "/posts/:path*"],
+};
 
 export default async function middleware(request: NextRequest) {
   const response = NextResponse.next();

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextFetchEvent, NextRequest, NextResponse } from "next/server";
 import { incrViews } from "./actions/middleware/views";
 
 // TODO: Improve my matcher.
@@ -6,14 +6,15 @@ export const config = {
   matcher: ["/about/:path*", "/posts/:path*"],
 };
 
-export default async function middleware(request: NextRequest) {
+export default async function middleware(
+  request: NextRequest,
+  context: NextFetchEvent
+) {
   const response = NextResponse.next();
 
   const ip = request.headers.get("x-forwarded-for") || request.ip || "unknown";
 
-  console.log("Middleware running on IP: ", ip);
-
-  await incrViews(ip, ["global_views"]);
+  await incrViews(ip, context, ["global_views"]);
 
   return response;
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -25,8 +25,6 @@ export const config = {
 export default async function middleware(request: NextRequest) {
   const response = NextResponse.next();
 
-  console.log(request.body, request.ip);
-
   incrViews(request.ip ?? "unknown", ["global_views"]);
 
   return response;

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "gray-matter": "^4.0.3",
+    "ipaddr.js": "^2.2.0",
     "lucide-react": "^0.447.0",
     "next": "14.2.14",
     "next-themes": "^0.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
+      ipaddr.js:
+        specifier: ^2.2.0
+        version: 2.2.0
       lucide-react:
         specifier: ^0.447.0
         version: 0.447.0(react@18.3.1)
@@ -1249,6 +1252,10 @@ packages:
   internal-slot@1.0.7:
     resolution: {integrity: sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==}
     engines: {node: '>= 0.4'}
+
+  ipaddr.js@2.2.0:
+    resolution: {integrity: sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==}
+    engines: {node: '>= 10'}
 
   is-arguments@1.1.1:
     resolution: {integrity: sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==}
@@ -3511,6 +3518,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.0.6
+
+  ipaddr.js@2.2.0: {}
 
   is-arguments@1.1.1:
     dependencies:


### PR DESCRIPTION
- Singleton-ify the `redis` instance
- Fix logs by adding `await` to all async calls
- Throttle visits counter on user's IP
- Group public IPs together
- Improve middleware matcher